### PR TITLE
Bump to GHC 8.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ sudo: required
 
 env:
  - CABALVER=1.24 GHCVER=7.10.3
- - CABALVER=1.24 GHCVER=8.0.1
+ - CABALVER=1.24 GHCVER=8.0.2
+ - CABALVER=2.0 GHCVER=8.2.2
+ - CABALVER=2.2 GHCVER=8.4.4
+ - CABALVER=2.4 GHCVER=8.6.3
 
 # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 

--- a/quantum-random.cabal
+++ b/quantum-random.cabal
@@ -42,15 +42,15 @@ source-repository head
 library
   hs-source-dirs:      src-lib
 
-  build-depends:       base          >=4.8  && <4.10,
+  build-depends:       base          >=4.8  && <4.13,
                        ansigraph     >=0.2  && <0.4,
-                       aeson         >=0.8  && <1.2,
+                       aeson         >=0.8  && <1.5,
                        text          >=1.2  && <1.3,
                        bytestring    >=0.10 && <0.11,
-                       http-conduit  >=2.1  && <2.3,
-                       ansi-terminal >=0.6  && <0.7,
+                       http-conduit  >=2.1  && <2.4,
+                       ansi-terminal >=0.6  && <0.10,
                        terminal-size >=0.3  && <0.4,
-                       directory     >=1.2  && <1.3
+                       directory     >=1.2  && <1.4
 
 
   exposed-modules:     Quantum.Random,
@@ -74,7 +74,7 @@ executable qrand
 
   main-is:             Main.hs
 
-  build-depends:       base          >=4.8 && <4.10,
+  build-depends:       base          >=4.8 && <4.13,
                        haskeline     >=0.7 && <0.8,
                        mtl           >=2.2 && <2.3,
                        quantum-random

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
-resolver: lts-7.15
+resolver: lts-13.8
 packages:
 - '.'
 flags: {}
 extra-package-dbs: []
-extra-deps: []
+extra-deps:
+- ansigraph-0.3.0.5


### PR DESCRIPTION
This pull request bumps to GHC 8.6.3 (stack resolver LTS 13.8) and relaxes the upper bounds on dependencies. It also adds GHC versions to `.travis.yml`. Tested on Windows 10.

